### PR TITLE
Add estimator for column dead time

### DIFF
--- a/massbank2db/db.py
+++ b/massbank2db/db.py
@@ -406,7 +406,7 @@ class MassbankDB(object):
                                    spectrum.get("copyright"),
                                    spectrum.get("license"),
                                    spectrum.get("column_name"),
-                                   None, # TODO: How to determine HILIC or RP?
+                                   None,  # TODO: How to determine HILIC or RP?
                                    spectrum.get("column_temperature"),
                                    spectrum.get("flow_gradient"),
                                    spectrum.get("flow_rate"),
@@ -559,7 +559,8 @@ class MassbankDB(object):
                 # --------------
                 # TODO: Remove loop here
                 peaks = self._mb_conn.execute("SELECT mz, intensity FROM spectra_peaks "
-                                              "    WHERE spectrum IS ? ORDER BY mz", (acc, ))
+                                              "    WHERE spectrum IS ? "
+                                              "    ORDER BY mz", (acc, ))
                 specs[-1]._mz, specs[-1]._int = [], []
                 for peak in peaks:
                     specs[-1]._mz.append(peak[0])

--- a/massbank2db/parser.py
+++ b/massbank2db/parser.py
@@ -185,6 +185,8 @@ def parse_column_name(column_name: str) -> Tuple[Union[None, Tuple[float, str]],
 
     :return:
     """
+    if column_name is None:
+        return None, None
 
     diameter = None
     length = None
@@ -233,6 +235,9 @@ def parse_flow_rate_string(flow_rate_str: str, aggregate_flow_rates: Optional[Ca
     :param aggregate_flow_rates:
     :return:
     """
+    if flow_rate_str is None:
+        return None
+
     # ---------------------------------------
     # Extract information about the flow rate
     # ---------------------------------------

--- a/massbank2db/tests/unittests_parser.py
+++ b/massbank2db/tests/unittests_parser.py
@@ -26,6 +26,52 @@
 import unittest
 
 from massbank2db.parser import get_AC_regex, get_CH_regex, get_meta_regex
+from massbank2db.parser import extract_information_to_calculate_column_deadtime
+
+
+class TestParsingOfColumnInformation(unittest.TestCase):
+    def test_column_dimensions_and_flowrate_from_column_name(self):
+        column_names = [
+            "Agilent RRHD Eclipse 50 x 2 mm, 1.8 uM",
+            "Acclaim RSLC C18 2.2um, 2.1x100mm, Thermo",
+            "ACQUITY UPLC BEH Amide 1.7 um 2.1x100mm, Waters",
+            "Acclaim RSLC C18 2.2um, 2.1x100mm, Thermo",
+            "BEH C18 1.7um, 2.1x100mm, Waters",
+            "Waters Acquity BEH C18 1.7um x 2.1 x 150 mm",
+            "Kinetex C18 EVO 2.6 um, 2.1x50 mm, precolumn 2.1x5 mm, Phenomenex",
+            "Develosil C30, Nomura Chemical",
+            "XBridge C18 3.5um, 2.1x50mm, Waters",
+            "Atlantis T3 3um, 3.0x150mm, Waters with guard column",
+            "XBridge C18 3.5um, 2.1x150mm, Waters",
+            "Acquity BEH C18 1.7um, 2.1x150mm (Waters)",
+            "Symmetry C18 Column, Waters",
+            "Kinetex Evo C18 2.6 um 50x2.1 mm, Phenomenex",
+            "Acquity bridged ethyl hybrid C18 (1.7 um, 2.1 mm * 100 mm, Waters)",
+            "Acquity UPLC Peptide BEH C18 column (50*2.1 mm; 1.7 um; 130A)(Waters Co.,Milford, MA, USA)",
+            "Kinetex Core-Shell C18 2.6 um, 3.0 x 100 mm, Phenomenex",
+            "Agilent C8 Cartridge Column 2.1X30mm 3.5 micron (guard); Agilent SB-Aq 2.1x50mm 1.8 micron (analytical)"
+        ]
+        diameters = [(2, "mm"), (2.1, ""), (2.1, ""), (2.1, ""), (2.1, ""), (2.1, ""), (2.1, ""), None, (2.1, ""),
+                     (3, ""), (2.1, ""), (2.1, ""), None, (2.1, "mm"), (2.1, "mm"), (2.1, "mm"), (3.0, ""), (2.1, "")]
+        lengths = [(50, ""), (100, "mm"), (100, "mm"), (100, "mm"), (100, "mm"), (150, "mm"), (50, "mm"), None,
+                   (50, "mm"), (150, "mm"), (150, "mm"), (150, "mm"), None, (50, ""), (100, "mm"), (50, ""), (100, "mm"),
+                   (50, "mm")]
+        flow_rates = [None] * len(diameters)
+
+        assert len(column_names) == len(diameters)
+        assert len(column_names) == len(lengths)
+        assert len(diameters) == len(lengths)
+
+        for idx, cn in enumerate(column_names):
+            dia, length, _ = extract_information_to_calculate_column_deadtime(cn, None)
+
+            try:
+                self.assertEqual(diameters[idx], dia)
+            except AssertionError as err:
+                print(cn)
+                raise err
+
+            self.assertEqual(lengths[idx], length)
 
 
 class TestRegularExpressions(unittest.TestCase):

--- a/massbank2db/tests/unittests_parser.py
+++ b/massbank2db/tests/unittests_parser.py
@@ -122,21 +122,18 @@ class TestParsingOfColumnInformation(unittest.TestCase):
             self.assertTrue(np.isscalar(_val))
             self.assertEqual(flow_rates[idx][1], _unit)
 
-    def test_flow_rate_parsing__TODO(self):
+    def test_flow_rate_parsing__currently_not_supported(self):
         self.skipTest("TODO: Cannot handle different units when multiple flow rates are reported.")
 
-        flow_rate_strs = ["0.3 ml/min at 0 min, 200 ul/min"]
-        flow_rates = [None]
+        flow_rate_strs = ["0.3 ml/min at 0 min, 200 ul/min",
+                          "0.3 ml/min at 0 min, 200 ul/min at 5 min",
+                          "200-320 (0-1 min); 200 (1-38 min) ul/min"]
+        flow_rates = [None, None, None]
 
         assert len(flow_rates) == len(flow_rate_strs)
 
         for idx, frstr in enumerate(flow_rate_strs):
             self.assertEqual(flow_rates[idx], parse_flow_rate_string(frstr))
-
-    def test_flow_rate_parsing__currently_not_handled(self):
-        self.skipTest("TODO")
-
-        "200-320 (0-1 min); 200 (1-38 min) ul/min'"
 
 
 class TestRegularExpressions(unittest.TestCase):

--- a/massbank2db/tests/unittests_parser.py
+++ b/massbank2db/tests/unittests_parser.py
@@ -133,6 +133,11 @@ class TestParsingOfColumnInformation(unittest.TestCase):
         for idx, frstr in enumerate(flow_rate_strs):
             self.assertEqual(flow_rates[idx], parse_flow_rate_string(frstr))
 
+    def test_flow_rate_parsing__currently_not_handled(self):
+        self.skipTest("TODO")
+
+        "200-320 (0-1 min); 200 (1-38 min) ul/min'"
+
 
 class TestRegularExpressions(unittest.TestCase):
     def test_AC_retention_time(self):

--- a/massbank2db/tests/unittests_utils.py
+++ b/massbank2db/tests/unittests_utils.py
@@ -31,9 +31,9 @@ from massbank2db.utils import estimate_column_deadtime
 
 class TestColumnDeadtimeEstimation(unittest.TestCase):
     def test_bordercases(self):
-        self.assertEqual(estimate_column_deadtime(np.nan, 1, 1), None)
-        self.assertEqual(estimate_column_deadtime(1, np.nan, 1), None)
-        self.assertEqual(estimate_column_deadtime(1, 1, np.nan), None)
+        self.assertEqual(estimate_column_deadtime(None, 1, 1), None)
+        self.assertEqual(estimate_column_deadtime(1, None, 1), None)
+        self.assertEqual(estimate_column_deadtime(1, 1, None), None)
 
     def test_correctness(self):
         np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.5, flowrate_unit="mL/Min"),

--- a/massbank2db/tests/unittests_utils.py
+++ b/massbank2db/tests/unittests_utils.py
@@ -36,17 +36,17 @@ class TestColumnDeadtimeEstimation(unittest.TestCase):
         self.assertEqual(estimate_column_deadtime(1, 1, None), None)
 
     def test_correctness(self):
-        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.5, flowrate_unit="mL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.5, flow_rate_unit="mL/Min"),
                                    0.519540885087412, )
-        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 500, flowrate_unit="uL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 500, flow_rate_unit="uL/Min"),
                                    0.519540885087412)
-        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.25, flowrate_unit="mL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.25, flow_rate_unit="mL/Min"),
                                    1.03908177017482)
-        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 250, flowrate_unit="uL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 250, flow_rate_unit="uL/Min"),
                                    1.03908177017482)
-        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 0.3, flowrate_unit="mL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 0.3, flow_rate_unit="mL/Min"),
                                    0.577267650097125)
-        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 300, flowrate_unit="uL/Min"),
+        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 300, flow_rate_unit="uL/Min"),
                                    0.577267650097125)
 
 

--- a/massbank2db/tests/unittests_utils.py
+++ b/massbank2db/tests/unittests_utils.py
@@ -1,0 +1,54 @@
+####
+#
+# The MIT License (MIT)
+#
+# Copyright 2021 Eric Bach <eric.bach@aalto.fi>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+####
+import numpy as np
+import unittest
+
+from massbank2db.utils import estimate_column_deadtime
+
+
+class TestColumnDeadtimeEstimation(unittest.TestCase):
+    def test_bordercases(self):
+        self.assertEqual(estimate_column_deadtime(np.nan, 1, 1), None)
+        self.assertEqual(estimate_column_deadtime(1, np.nan, 1), None)
+        self.assertEqual(estimate_column_deadtime(1, 1, np.nan), None)
+
+    def test_correctness(self):
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.5, flowrate_unit="mL/Min"),
+                                   0.519540885087412, )
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 500, flowrate_unit="uL/Min"),
+                                   0.519540885087412)
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 0.25, flowrate_unit="mL/Min"),
+                                   1.03908177017482)
+        np.testing.assert_allclose(estimate_column_deadtime(150, 2.1, 250, flowrate_unit="uL/Min"),
+                                   1.03908177017482)
+        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 0.3, flowrate_unit="mL/Min"),
+                                   0.577267650097125)
+        np.testing.assert_allclose(estimate_column_deadtime(100, 2.1, 300, flowrate_unit="uL/Min"),
+                                   0.577267650097125)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/massbank2db/utils.py
+++ b/massbank2db/utils.py
@@ -23,8 +23,9 @@
 # SOFTWARE.
 #
 ####
-
 import numpy as np
+
+from typing import Optional
 
 # TODO: Currently unsupported precursor-types
 #  '[M+CH3COOH-H]-': None,
@@ -86,7 +87,7 @@ def get_mass_error_in_ppm(monoisotopic_mass, precursor_mz, precursor_type):
     return (abs(theoretical_precursor_mz - precursor_mz) * 1e6) / theoretical_precursor_mz
 
 
-def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min"):
+def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min") -> Optional[float]:
     """
     Estimates the column's deadtime given it's length, diameter and flowrate:
 
@@ -98,7 +99,7 @@ def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min")
     :param flowrate_unit: string, defining the unit of the given flowrate
     :return: scalar, estimated column deadtime or None if for any of the required input parameters np.isnan is True.
     """
-    if np.isnan(length) or np.isnan(diameter) or np.isnan(flowrate):
+    if length is None or diameter is None or flowrate is None:
         return None
 
     if flowrate_unit.lower() == "ul/min":

--- a/massbank2db/utils.py
+++ b/massbank2db/utils.py
@@ -87,7 +87,7 @@ def get_mass_error_in_ppm(monoisotopic_mass, precursor_mz, precursor_type):
     return (abs(theoretical_precursor_mz - precursor_mz) * 1e6) / theoretical_precursor_mz
 
 
-def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min") -> Optional[float]:
+def estimate_column_deadtime(length, diameter, flow_rate, flow_rate_unit="uL/min") -> Optional[float]:
     """
     Estimates the column's deadtime given it's length, diameter and flowrate:
 
@@ -95,18 +95,18 @@ def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min")
 
     :param length: scalar, length of the column in mm
     :param diameter: scalar, diameter of the column in mm
-    :param flowrate: scalar, flowrate of the column in 'flowrate_unit'
-    :param flowrate_unit: string, defining the unit of the given flowrate
+    :param flow_rate: scalar, flowrate of the column in 'flowrate_unit'
+    :param flow_rate_unit: string, defining the unit of the given flowrate
     :return: scalar, estimated column deadtime or None if for any of the required input parameters np.isnan is True.
     """
-    if length is None or diameter is None or flowrate is None:
+    if length is None or diameter is None or flow_rate is None:
         return None
 
-    if flowrate_unit.lower() == "ul/min":
-        flowrate /= 1000.0  # convert to mL/min
-    elif flowrate_unit.lower() == "ml/min":
+    if flow_rate_unit.lower() == "ul/min":
+        flow_rate /= 1000.0  # convert to mL/min
+    elif flow_rate_unit.lower() == "ml/min":
         pass
     else:
-        raise ValueError("Invalid flowrate unit: '%s'." % flowrate_unit)
+        raise ValueError("Invalid flowrate unit: '%s'." % flow_rate_unit)
 
-    return ((np.pi * (diameter / 2)**2 * length * 0.5) / 1000) / flowrate
+    return ((np.pi * (diameter / 2)**2 * length * 0.5) / 1000) / flow_rate

--- a/massbank2db/utils.py
+++ b/massbank2db/utils.py
@@ -24,6 +24,8 @@
 #
 ####
 
+import numpy as np
+
 # TODO: Currently unsupported precursor-types
 #  '[M+CH3COOH-H]-': None,
 #  '[M-2H2O+H]+': None,
@@ -36,6 +38,7 @@
 #  '[M+H-NH3]+': None,
 #  '[M+H-C9H10O5]+': None,
 #  '[M-C6H10O5+H]+': None
+
 
 def get_precursor_mz(exact_mass, precursor_type):
     """
@@ -81,3 +84,28 @@ def get_mass_error_in_ppm(monoisotopic_mass, precursor_mz, precursor_type):
         return None
 
     return (abs(theoretical_precursor_mz - precursor_mz) * 1e6) / theoretical_precursor_mz
+
+
+def estimate_column_deadtime(length, diameter, flowrate, flowrate_unit="uL/min"):
+    """
+    Estimates the column's deadtime given it's length, diameter and flowrate:
+
+        dt = ((pi * (diameter * 0.5)^2 * length * 0.5) / 1000) / flowrate(in mL/min)
+
+    :param length: scalar, length of the column in mm
+    :param diameter: scalar, diameter of the column in mm
+    :param flowrate: scalar, flowrate of the column in 'flowrate_unit'
+    :param flowrate_unit: string, defining the unit of the given flowrate
+    :return: scalar, estimated column deadtime or None if for any of the required input parameters np.isnan is True.
+    """
+    if np.isnan(length) or np.isnan(diameter) or np.isnan(flowrate):
+        return None
+
+    if flowrate_unit.lower() == "ul/min":
+        flowrate /= 1000.0  # convert to mL/min
+    elif flowrate_unit.lower() == "ml/min":
+        pass
+    else:
+        raise ValueError("Invalid flowrate unit: '%s'." % flowrate_unit)
+
+    return ((np.pi * (diameter / 2)**2 * length * 0.5) / 1000) / flowrate


### PR DESCRIPTION
In this pull-request we implemented a parser to extract the relevant information to estimate the column-dead-time from the Massbank LC meta-data. 

However, it still falls short on handling some particular meta-data formats. 